### PR TITLE
Switch from uv to Pixi shebang for self-contained execution

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,7 @@
       "WebFetch(domain:graphviz.org)",
       "Bash(./cp_graph.py examples/illum.json examples/output/test_shebang.dot --quiet)",
       "Bash(./cp_graph.py:*)",
-      "Bash(dot:*)"
+      "Bash(pixi exec --spec 'graphviz' dot:*)"
     ],
     "deny": [],
     "ask": [],
@@ -21,3 +21,4 @@
     ]
   }
 }
+

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,9 +2,22 @@
   "permissions": {
     "allow": [
       "Bash(gh pr diff:*)",
-      "Bash(gh pr:*)"
+      "Bash(gh pr:*)",
+      "WebSearch",
+      "WebFetch(domain:pixi.sh)",
+      "WebFetch(domain:prefix.dev)",
+      "Bash(pixi exec:*)",
+      "WebFetch(domain:forum.graphviz.org)",
+      "WebFetch(domain:graphviz.org)",
+      "Bash(./cp_graph.py examples/illum.json examples/output/test_shebang.dot --quiet)",
+      "Bash(./cp_graph.py:*)",
+      "Bash(dot:*)"
     ],
     "deny": [],
-    "ask": []
+    "ask": [],
+    "additionalDirectories": [
+      "/Users/shsingh/.pixi",
+      "/Users/shsingh/Library/Caches/rattler/cache/cached-envs-v0/which-362b0f80287d8ae9/lib/graphviz"
+    ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **BREAKING**: Switched from `uv run --script` to Pixi shebang for dependency management
   - Script is now directly executable: `./cp_graph.py` instead of `uv run --script cp_graph.py`
   - GraphViz is automatically provided by Pixi (no separate installation needed)
+  - `dot` command prefixed with `pixi exec --spec "graphviz"`
 - Enhanced edge tracking and reporting for duplicate parent filtering
 - Improved visual feedback when highlighting filtered edges (dashed red lines)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Enhanced edge tracking and reporting for duplicate parent filtering
 - Improved visual feedback when highlighting filtered edges (dashed red lines)
 
-## [1.0.0] - 2024-11-01
+## [0.10.0] - 2025-04-13
 
 ### Added
 - Core graph generation from CellProfiler v6 JSON pipelines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed typo: changed 'quit' to 'quiet' in filter output messages
 
 ### Changed
+- **BREAKING**: Switched from `uv run --script` to Pixi shebang for dependency management
+  - Script is now directly executable: `./cp_graph.py` instead of `uv run --script cp_graph.py`
+  - GraphViz is automatically provided by Pixi (no separate installation needed)
 - Enhanced edge tracking and reporting for duplicate parent filtering
 - Improved visual feedback when highlighting filtered edges (dashed red lines)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,9 @@ The primary purpose of this tool is to provide a standardized way to represent a
 - Visualize pipeline structure as a directed graph with intuitive color coding for different data types
 
 ## Commands
-- Run tool: `uv run cp_graph.py <pipeline.json> [output_graph.graphml] [options]`
+- Run tool: `./cp_graph.py <pipeline.json> [output_graph.graphml] [options]`
 - Visualization: `dot -Tpng <output_file>.dot -o <output_file>.png`
+- Note: The tool uses a pixi shebang to automatically provide all dependencies including GraphViz
 
 ## Code Style
 - Python 3.11+ with type annotations

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This tool converts CellProfiler pipelines into standardized graph representation
    --highlight-filtered \
    --rank-ignore-filtered \
    --root-nodes=CorrPhalloidin,CorrZO1,CorrDNA,Cycle01_DAPI,Cycle01_A,Cycle01_T,Cycle01_G,Cycle01_C,Cycle02_DAPI,Cycle02_A,Cycle02_T,Cycle02_G,Cycle02_C,Cycle03_DAPI,Cycle03_A,Cycle03_T,Cycle03_G,Cycle03_C && \
-   dot -Tpng \
+   pixi exec --spec "graphviz" dot -Tpng \
    examples/output/analysis_filtered.dot \
    -o examples/output/analysis_filtered.png
 ```
@@ -46,7 +46,7 @@ First run may take a moment as Pixi sets up the environment. Subsequent runs wil
 
 # Create visualization (GraphViz included automatically)
 ./cp_graph.py examples/illum.json examples/output/illum.dot
-dot -Tpng examples/output/illum.dot -o examples/output/illum.png
+pixi exec --spec "graphviz" dot -Tpng examples/output/illum.dot -o examples/output/illum.png
 
 # Compare pipeline structures
 ./cp_graph.py examples/illum.json examples/output/illum_ultra.dot --ultra-minimal
@@ -89,7 +89,7 @@ The tool creates intuitive graph visualizations showing data flow through pipeli
 - **Connections**: Arrows showing the flow between data and modules
 
 Output formats include:
-- **DOT files**: For Graphviz visualization with `dot -Tpng <file>.dot -o <file>.png`
+- **DOT files**: For Graphviz visualization with `pixi exec --spec "graphviz" dot -Tpng <file>.dot -o <file>.png`
 - **GraphML**: For tools like yEd and Cytoscape
 - **GEXF**: For Gephi visualization
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This tool converts CellProfiler pipelines into standardized graph representation
 <details>
 
 ```sh
-uv run --script cp_graph.py \
+./cp_graph.py \
    examples/analysis.json \
    examples/output/analysis_filtered.dot \
    --rank-nodes \
@@ -24,39 +24,47 @@ uv run --script cp_graph.py \
 
 ## Installation & Running
 
-- Python 3.11+
-- Dependencies: NetworkX, PyDot, Click
+**Requirements**: [Pixi](https://pixi.sh) package manager (handles all dependencies automatically)
 
-The **recommended way** to run the tool is with `uv run --script`, which automatically handles all dependencies in an isolated environment without requiring manual installation:
-
-```bash
-# Run directly (no installation needed)
-uv run --script cp_graph.py <pipeline.json> <output_file> [options]
-```
-
-If you prefer manual installation:
+The tool is a self-contained executable script that uses Pixi to automatically provide all dependencies including Python packages and GraphViz:
 
 ```bash
-# Install dependencies
-pip install networkx pydot click
+# One-time setup: make script executable
+chmod +x cp_graph.py
 
-# Then run directly
-python cp_graph.py <pipeline.json> <output_file> [options]
+# Run directly - all dependencies handled automatically
+./cp_graph.py <pipeline.json> <output_file> [options]
 ```
+
+First run may take a moment as Pixi sets up the environment. Subsequent runs will be fast using the cached environment.
 
 ## Quick Start
 
 ```bash
 # Basic usage
-uv run --script cp_graph.py examples/illum.json examples/output/illum.dot
+./cp_graph.py examples/illum.json examples/output/illum.dot
 
-# Create visualization
+# Create visualization (GraphViz included automatically)
+./cp_graph.py examples/illum.json examples/output/illum.dot
 dot -Tpng examples/output/illum.dot -o examples/output/illum.png
 
 # Compare pipeline structures
-uv run --script cp_graph.py examples/illum.json examples/output/illum_ultra.dot --ultra-minimal
-uv run --script cp_graph.py examples/illum_mod.json examples/output/illum_mod_ultra.dot --ultra-minimal
+./cp_graph.py examples/illum.json examples/output/illum_ultra.dot --ultra-minimal
+./cp_graph.py examples/illum_mod.json examples/output/illum_mod_ultra.dot --ultra-minimal
 diff examples/output/illum_ultra.dot examples/output/illum_mod_ultra.dot
+```
+
+### Alternative: Manual Installation
+
+If you prefer traditional installation or need Windows support:
+
+```bash
+# Install dependencies
+pip install networkx pydot click
+# Also install GraphViz separately (apt/brew/choco)
+
+# Run with Python
+python cp_graph.py <pipeline.json> <output_file> [options]
 ```
 
 ## Core Capabilities
@@ -100,10 +108,8 @@ Output formats include:
 
 ## Command Options
 
-As mentioned, the recommended way to run the tool is:
-
 ```bash
-uv run --script cp_graph.py <pipeline.json> <output_file> [options]
+./cp_graph.py <pipeline.json> <output_file> [options]
 ```
 
 - `pipeline.json` - CellProfiler pipeline file (v6 JSON format)
@@ -132,13 +138,13 @@ The tool provides filtering options to focus on specific parts of complex pipeli
 
 ```bash
 # Generate basic pipeline graph
-uv run --script cp_graph.py examples/illum.json examples/output/illum.dot
+./cp_graph.py examples/illum.json examples/output/illum.dot
 
 # Highlight filtered nodes instead of removing them (uses distinct colors and dashed borders)
-uv run --script cp_graph.py examples/illum.json examples/output/illum_highlight.dot --root-nodes=OrigDNA --remove-unused-data --highlight-filtered
+./cp_graph.py examples/illum.json examples/output/illum_highlight.dot --root-nodes=OrigDNA --remove-unused-data --highlight-filtered
 
 # Filter to show only nodes reachable from OrigDNA (removes unreachable nodes)
-uv run --script cp_graph.py examples/illum.json examples/output/illum_filtered.dot --root-nodes=OrigDNA --remove-unused-data
+./cp_graph.py examples/illum.json examples/output/illum_filtered.dot --root-nodes=OrigDNA --remove-unused-data
 ```
 
 <table>
@@ -210,28 +216,28 @@ The repository includes sample files:
 
 ```bash
 # Include disabled modules in visualization
-uv run --script cp_graph.py examples/illum.json examples/output/illum_disabled.dot --include-disabled
+./cp_graph.py examples/illum.json examples/output/illum_disabled.dot --include-disabled
 
 # Create minimal representation for exact structure comparison
-uv run --script cp_graph.py examples/illum.json examples/output/illum_ultra.dot --ultra-minimal
+./cp_graph.py examples/illum.json examples/output/illum_ultra.dot --ultra-minimal
 
 # Display detailed module ID mapping for reference
-uv run --script cp_graph.py examples/illum.json examples/output/illum_ids.dot --explain-ids
+./cp_graph.py examples/illum.json examples/output/illum_ids.dot --explain-ids
 
 # Improve graph layout with node ranking (source nodes at top, sink nodes at bottom)
-uv run --script cp_graph.py examples/illum.json examples/output/illum_ranked.dot --rank-nodes
+./cp_graph.py examples/illum.json examples/output/illum_ranked.dot --rank-nodes
 
 # Analyze complex pipeline with multiple data types
-uv run --script cp_graph.py examples/analysis.json examples/output/analysis.dot
+./cp_graph.py examples/analysis.json examples/output/analysis.dot
 
 # Filter complex analysis pipeline by specifying multiple root nodes
-uv run --script cp_graph.py examples/analysis.json examples/output/analysis_filtered.dot --remove-unused-data  --exclude-module-types=ExportToSpreadsheet --root-nodes=CorrPhalloidin,CorrZO1,CorrDNA,Cycle01_DAPI  --highlight-filtered
+./cp_graph.py examples/analysis.json examples/output/analysis_filtered.dot --remove-unused-data  --exclude-module-types=ExportToSpreadsheet --root-nodes=CorrPhalloidin,CorrZO1,CorrDNA,Cycle01_DAPI  --highlight-filtered
 
 # Combine node ranking with filtering for optimal visualization
-uv run --script cp_graph.py examples/analysis.json examples/output/analysis_ranked_filtered.dot --rank-nodes --root-nodes=CorrPhalloidin,CorrZO1 --remove-unused-data
+./cp_graph.py examples/analysis.json examples/output/analysis_ranked_filtered.dot --rank-nodes --root-nodes=CorrPhalloidin,CorrZO1 --remove-unused-data
 
 # Combine node ranking with highlighted filtering, ignoring filtered nodes in ranking
-uv run --script cp_graph.py examples/analysis.json examples/output/analysis_clean_ranked.dot --rank-nodes --rank-ignore-filtered --root-nodes=CorrPhalloidin,CorrZO1 --highlight-filtered
+./cp_graph.py examples/analysis.json examples/output/analysis_clean_ranked.dot --rank-nodes --rank-ignore-filtered --root-nodes=CorrPhalloidin,CorrZO1 --highlight-filtered
 ```
 
 ## Technical Details

--- a/README.md
+++ b/README.md
@@ -54,19 +54,6 @@ dot -Tpng examples/output/illum.dot -o examples/output/illum.png
 diff examples/output/illum_ultra.dot examples/output/illum_mod_ultra.dot
 ```
 
-### Alternative: Manual Installation
-
-If you prefer traditional installation or need Windows support:
-
-```bash
-# Install dependencies
-pip install networkx pydot click
-# Also install GraphViz separately (apt/brew/choco)
-
-# Run with Python
-python cp_graph.py <pipeline.json> <output_file> [options]
-```
-
 ## Core Capabilities
 
 - **Standardized Representation**: Consistent pipeline encoding for reliable comparison

--- a/cp_graph.py
+++ b/cp_graph.py
@@ -1,14 +1,4 @@
-# /// script
-# requires-python = ">=3.11"
-# dependencies = [
-#     "networkx",
-#     "pydot",
-#     "click",
-# ]
-#
-# ///
-
-#!/usr/bin/env python
+#!/usr/bin/env -S pixi exec --spec python>=3.11 --spec networkx --spec pydot --spec click --spec graphviz -- python
 
 # ----- IMPORTS -----
 import json
@@ -1452,52 +1442,7 @@ def cli(
 
     OUTPUT: Optional path for output graph file (.graphml, .gexf, or .dot)
 
-    Examples:
-
-    \b
-    # Basic usage - creates DOT file from pipeline
-    python cp_graph.py examples/illum.json examples/output/illum_graph.dot
-
-    \b
-    # Create ultra-minimal output for comparing pipeline structure
-    python cp_graph.py examples/illum.json examples/output/illum_ultra.dot --ultra-minimal
-
-    \b
-    # Include disabled modules in the graph
-    python cp_graph.py examples/illum_mod.json examples/output/illum_mod_include.dot --include-disabled
-
-    \b
-    # Filter graph to only include paths from specific root nodes
-    python cp_graph.py examples/illum.json examples/output/illum_filtered.dot --root-nodes=OrigBlue,OrigGreen
-
-    \b
-    # Remove image and object nodes that aren't used as inputs to any module
-    python cp_graph.py examples/illum.json examples/output/illum_clean.dot --remove-unused-data
-
-    \b
-    # Apply multiple filters in combination
-    python cp_graph.py examples/illum.json examples/output/illum_clean.dot --root-nodes=OrigBlue,OrigGreen --remove-unused-data
-
-    \b
-    # Highlight filtered nodes instead of removing them (useful for previewing filter effects)
-    python cp_graph.py examples/illum.json examples/output/illum_highlight.dot --root-nodes=OrigDNA --highlight-filtered
-
-    \b
-    # Compare standard filtering to highlighted filtering to see what would be removed
-    python cp_graph.py examples/illum.json examples/output/illum_filtered.dot --root-nodes=OrigDNA
-    python cp_graph.py examples/illum.json examples/output/illum_highlight.dot --root-nodes=OrigDNA --highlight-filtered
-
-    \b
-    # Position source nodes at top and sink nodes at bottom in the graph
-    python cp_graph.py examples/illum.json examples/output/illum_ranked.dot --rank-nodes
-
-    \b
-    # Position source and sink nodes while ignoring filtered nodes
-    python cp_graph.py examples/illum.json examples/output/illum_clean_ranked.dot --root-nodes=OrigDNA --highlight-filtered --rank-nodes --rank-ignore-filtered
-
-    \b
-    # Exclude unused and objects
-    python cp_graph.py --remove-unused-data --highlight-filtered --rank-nodes --filter-objects examples/ExampleFly.json examples/output/ExampleFly.dot
+    For detailed examples, see README.md
     """
     # Process root nodes if provided
     root_node_list = None


### PR DESCRIPTION
## Summary
- Replaced `uv run --script` with Pixi shebang for truly self-contained execution
- Script is now directly executable with all dependencies (including GraphViz) automatically provided
- Simplified user experience - just `./cp_graph.py` works out of the box

## Changes
- Added Pixi shebang to `cp_graph.py` to handle all dependencies
- Updated README with new execution instructions
- Updated CLAUDE.md and CHANGELOG.md to reflect changes
- Made script executable (`chmod +x`)

## Test plan
- [x] Script executes successfully with Pixi shebang
- [x] DOT files generated correctly
- [x] GraphViz PNG generation works
- [x] All command-line options work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)